### PR TITLE
Fix consistent crash caused by Galacticraft re-entry to the overworld

### DIFF
--- a/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
+++ b/src/main/java/gregtech/api/util/GT_SpawnEventHandler.java
@@ -9,12 +9,12 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.event.entity.living.LivingSpawnEvent.CheckSpawn;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class GT_SpawnEventHandler {
 
-    public static volatile List<int[]> mobReps = new ArrayList();
+    public static volatile List<int[]> mobReps = new CopyOnWriteArrayList<>();
 
     public GT_SpawnEventHandler() {
         MinecraftForge.EVENT_BUS.register(this);


### PR DESCRIPTION
As the title says. I have a very consistent crash that happens when re-entering the overworld via Galacticraft. It occurs ~100% of the time; I've not yet seen it not happen.

[Crash log](https://gist.github.com/queer/b07c3dde5884fb9587d232f07e4dcdbf)

Since it's caused by this list being concurrently modified, this seemed to be the easiest fix.

I unfortunately do not have a more consistent reproduction method than "re-enter the Overworld via Galacticraft."